### PR TITLE
Prettier should ignore changelog generated by lerna-changelog

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
+/CHANGELOG.md
 /pnpm-lock.yaml
 /test-app/dist


### PR DESCRIPTION
The changelog is generated automatically by lerna-changelog. Lerna-changelog is not following the Prettier opinions for Markdown. This is causing linting to fail after release.

Excluding the changelog from Prettier seems to be the easiest workaround for now.

Closes #6 