### PR TITLE
skip inline scripts

### DIFF
--- a/webpack-subresource-integrity-embroider/index.js
+++ b/webpack-subresource-integrity-embroider/index.js
@@ -33,6 +33,12 @@ class SubresourceIntegrityPlugin {
               element.tagName === "SCRIPT"
                 ? element.getAttribute("src")
                 : element.getAttribute("href");
+
+            if (!assetLocation) {
+              // skip inline scripts
+              return;
+            }
+
             // strip rootURL or publishPath from locations
             const fileName = assetLocation.replace(
               rootURLOrPublicPathRegex,


### PR DESCRIPTION
Thank you for this great addon - just what I was looking for after the popular webpack plugin didn't work ;)

Hope this fix makes sense as I got an error with an inline script (no src):

```
- broccoliBuilderErrorStack: TypeError: Cannot read properties of null (reading 'replace')
    at ~/my-project/node_modules/.pnpm/webpack-subresource-integrity-embroider@0.2.1/node_modules/webpack-subresource-integrity-embroider/index.js:37:44
    at Array.map (<anonymous>)
    at ~/my-project/node_modules/.pnpm/webpack-subresource-integrity-embroider@0.2.1/node_modules/webpack-subresource-integrity-embroider/index.js:29:48
```
